### PR TITLE
Fix fetching commit list

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -64,7 +64,7 @@ action('fetchCommitListSuccess', 'commitList');
 action('fetchCommitListFailure', 'error');
 
 function shouldFetchCommitList(state) {
-  return !(state && state.commitList && state.commitList.length >= 0);
+  return !(state && state.commitList);
 }
 
 async function realFetchCommitList() {

--- a/src/reducers/commit-list.js
+++ b/src/reducers/commit-list.js
@@ -4,7 +4,7 @@ const {
   APPEND_COMMIT_LIST_SUCCESS,
 } = types;
 
-const initState = [];
+const initState = null;
 
 export default function commitList(state = initState, {type, payload}) {
   switch (type) {

--- a/test/reducers/commit-list_test.js
+++ b/test/reducers/commit-list_test.js
@@ -9,8 +9,8 @@ const {
 } = types;
 
 describe('commitList', () => {
-  it('should be empty array initially', () => {
-    expect(commitList(undefined, {})).toEqual([]);
+  it('should be null initially', () => {
+    expect(commitList(undefined, {})).toBe(null);
   });
 
   it('should return commits by fetching commit list', () => {


### PR DESCRIPTION
トップページのコミットリストの読み込み時に`state.commitList`にfalslyな値を期待していたが、実際は`[]`だったので読み込みが行われず、ずっとLoadingのまま進まなかったので修正。

Componentsのテストの必要性を感じる。