### PR TITLE
[ci skip] Fix main script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/makenowjust/commlog#readme",
   "license": "MIT",
-  "main": "index.js",
+  "main": "src/index.js",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
package.json内の`main`のパスを直した。