### PR TITLE
Update dependencies (React v0.13 -> v0.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
   "dependencies": {
     "history": "^1.9.1",
     "isomorphic-fetch": "^2.1.1",
-    "mdast-react-component": "^1.0.1",
+    "mdast": "^1.2.0",
+    "mdast-react": "^0.3.0",
     "radium": "^0.14.1",
-    "react": "^0.13.3",
-    "react-redux": "^2.1.2",
-    "react-router": "^1.0.0-rc1",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-redux": "^3.1.0",
+    "react-router": "^1.0.0-rc3",
     "redux": "^3.0.0",
     "sanitize.css": "^2.0.0"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/app.css"></link>
   </head>
   <body>
+    <main></main>
     <script src="js/app.js"></script>
   </body>
 </html>

--- a/src/components/commit.js
+++ b/src/components/commit.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Radium from 'radium'
 import { Link } from 'react-router'
-import Mdast from 'mdast-react-component'
+import Markdown from './markdown'
 
 @Radium
 export default class Commit extends React.Component {
@@ -45,7 +45,7 @@ export default class Commit extends React.Component {
     return (
       <section style={[style.section]}>
         <div style={[style.container]}>
-          <Mdast>{message}</Mdast>
+          <Markdown>{message}</Markdown>
           <div style={[style.info]}>
             <a style={[style.rightPad]} href={comitterUrl}>
               {comitterName}

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import mdast from 'mdast'
+import mdastRender from 'mdast-react'
+
+export default class Markdown extends React.Component {
+  static propTypes = {
+    children: React.PropTypes.string.isRequired
+  }
+
+  constructor (props) {
+    super(props)
+  }
+
+  render () {
+    return mdast().use(mdastRender).process(this.props.children)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import 'babel/polyfill'
 import 'sanitize.css'
 
 import React from 'react'
+import { render } from 'react-dom'
 import {
   Router,
   Route, IndexRoute
@@ -14,15 +15,13 @@ import CommitPage from './containers/commit-page'
 import store from './store'
 import history from './history'
 
-React.render(
+render(
   <Provider store={store}>
-    {() => (
-      <Router history={history}>
-        <Route path='/' component={App}>
-          <IndexRoute component={CommitListPage} />
-          <Route path='commit/:sha' component={CommitPage} />
-        </Route>
-      </Router>
-    )}
+    <Router history={history}>
+      <Route path='/' component={App}>
+        <IndexRoute component={CommitListPage} />
+        <Route path='commit/:sha' component={CommitPage} />
+      </Route>
+    </Router>
   </Provider>,
   document.body)

--- a/src/index.js
+++ b/src/index.js
@@ -24,4 +24,4 @@ render(
       </Route>
     </Router>
   </Provider>,
-  document.body)
+  document.getElementsByTagName('main')[0])


### PR DESCRIPTION
主な変更

  - Reactのバージョンをv0.13からv0.14にした
  - mdast-react-componentを使うのをやめて、mdast-reactをラップしたコンポーネントを自前で使うようにした
  - react-routerのバージョンをちょっと上げた（rc版の人柱）
